### PR TITLE
Support of Typo3 9.5

### DIFF
--- a/Classes/Backend/ExtensionManagerConfiguration.php
+++ b/Classes/Backend/ExtensionManagerConfiguration.php
@@ -29,6 +29,7 @@ namespace TYPO3Extension\Imagecycle\Backend;
  ***************************************************************/
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Class that renders fields for the extensionmanager configuration
@@ -111,7 +112,7 @@ class ExtensionManagerConfiguration
 			'useSelectInsteadCheckbox',
 			'allowedDbTypesForCaption',
 		);
-		$confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+		$confArr = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
 		foreach ($confDefault as $val) {
 			if (!isset($confArr[$val]) && !isset($_POST['data'][$val])) {
 				return false;

--- a/Classes/Backend/ItemsProcFunc.php
+++ b/Classes/Backend/ItemsProcFunc.php
@@ -28,7 +28,7 @@ namespace TYPO3Extension\Imagecycle\Backend;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
-use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 
@@ -47,7 +47,7 @@ class ItemsProcFunc
 	 */
 	public function getEffects($config, $item)
 	{
-		$confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+		$confArr = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
 		$availableEffects = GeneralUtility::trimExplode(',', $confArr['effects'], true);
 		if (count($availableEffects) < 1) {
 			$availableEffects = array('none','blindX','blindY','blindZ','cover','curtainX','curtainY','fade','fadeout','fadeZoom','growX','growY','scrollUp','scrollDown','scrollLeft','scrollRight','scrollHorz','scrollVert','shuffle','slideX','slideY','toss','turnUp','turnDown','turnLeft','turnRight','uncover','wipe','zoom','all');
@@ -84,7 +84,7 @@ class ItemsProcFunc
 	 */
 	public function getEffectsCoin($config, $item)
 	{
-		$confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+	    $confArr = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
 		$availableEffects = GeneralUtility::trimExplode(',', $confArr['effectsCoin'], true);
 		if (count($availableEffects) < 1) {
 			$availableEffects = array('random','swirl','rain','straight');
@@ -121,7 +121,7 @@ class ItemsProcFunc
 	 */
 	public function getEffectsNivo($config, $item)
 	{
-		$confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+	    $confArr = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
 		$availableEffects = GeneralUtility::trimExplode(',', $confArr['effectsNivo'], true);
 		if (count($availableEffects) < 1) {
 			$availableEffects = array('random','sliceDown','sliceDownLeft','sliceUp','sliceUpLeft','sliceUpDown','sliceUpDownLeft','fold','fade','slideInRight','slideInLeft', 'boxRandom', 'boxRain', 'boxRainReverse', 'boxRainGrow', 'boxRainGrowReverse');
@@ -158,7 +158,7 @@ class ItemsProcFunc
 	*/
 	public function getThemesNivo($config, $item)
 	{
-		$confArr = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+	    $confArr = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
 		if (! is_dir(GeneralUtility::getFileAbsFileName($confArr['nivoThemeFolder']))) {
 			// if the defined folder does not exist, define the default folder
 			GeneralUtility::devLog('Path \''.$confArr['nivoThemeFolder'].'\' does not exist', 'imagecycle', 1);

--- a/Classes/Controller/PageRenderer.php
+++ b/Classes/Controller/PageRenderer.php
@@ -30,6 +30,7 @@ namespace TYPO3Extension\Imagecycle\Controller;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 
 /**
  * This class implements a all needed functions to add Javascripts and Stylesheets to a page
@@ -170,7 +171,10 @@ class PageRenderer
 	 * @return string
 	 */
 	public function getPath($path = '') {
-		return $this->getTypoScriptFrontendController()->tmpl->getFileName($path);
+        if ($path !== '')
+            return GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($path);
+
+        return $path;
 	}
 
 	/**

--- a/Classes/Controller/WizardIcon.php
+++ b/Classes/Controller/WizardIcon.php
@@ -66,7 +66,7 @@ class WizardIcon
         foreach ($wizardArray as $type => $wizardConf) {
             $params = '&defVals[tt_content][CType]=list&defVals[tt_content][list_type]=' . $wizardConf['list_type'];
             $wizardItem = array(
-                'title' => $GLOBALS['LANG']->sL('LLL:EXT:' . IMAGECYLCE_EXT . 'locallang.xml:' . $type . '_title')
+                'title' => $GLOBALS['LANG']->sL('LLL:EXT:' . IMAGECYLCE_EXT . 'locallang.xml:' . $type . '_title'),
                 'description' => $GLOBALS['LANG']->sL('LLL:EXT:' . IMAGECYLCE_EXT . DIV2007_LANGUAGE_SUBPATH . 'locallang.xml:' . $type . '_plus_wiz_description'),
                 'params' => $params
             );

--- a/Classes/Form/FormDataProvider/AllowedGroupField.php
+++ b/Classes/Form/FormDataProvider/AllowedGroupField.php
@@ -15,6 +15,7 @@ namespace TYPO3Extension\Imagecycle\Form\FormDataProvider;
  */
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
 use TYPO3\CMS\Backend\Form\FormDataProvider\AbstractItemProvider;
 
@@ -67,7 +68,7 @@ class AllowedGroupField extends AbstractItemProvider implements FormDataProvider
     {
         $allowedTypesForCaption = '';
 
-        $configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+        $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
         if (!empty($configuration['allowedDbTypesForCaption'])) {
             $allowedTypesForCaption = $configuration['allowedDbTypesForCaption'];
         }

--- a/Classes/Form/FormDataProvider/SelectOrCheckboxField.php
+++ b/Classes/Form/FormDataProvider/SelectOrCheckboxField.php
@@ -17,6 +17,7 @@ namespace TYPO3Extension\Imagecycle\Form\FormDataProvider;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
 use TYPO3\CMS\Backend\Form\FormDataProvider\AbstractItemProvider;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 
 /**
  * Resolves custom select or checkbox field.
@@ -71,7 +72,7 @@ class SelectOrCheckboxField extends AbstractItemProvider implements FormDataProv
      */
     protected function useSelectInsteadCheckbox()
     {
-        $configuration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['imagecycle']);
+        $configuration = GeneralUtility::makeInstance(ExtensionConfiguration::class)->get('backend');
         return (!empty($configuration['useSelectInsteadCheckbox']));
     }
 }

--- a/Classes/Miscellaneous/TtNewsUserFunctions.php
+++ b/Classes/Miscellaneous/TtNewsUserFunctions.php
@@ -32,6 +32,7 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
 
 class TtNewsUserFunctions {
 	/**
@@ -120,7 +121,7 @@ class TtNewsUserFunctions {
 			$instanceClass = ($conf['instanceClass'] ? $conf['instanceClass'] : ExtensionManagementUtility::extPath('imagecycle').'pi1/class.tx_imagecycle_pi1.php');
 			if (! file_exists($instanceClass)) {
 				// try to get the filename if file not exists
-				$instanceClass = $GLOBALS['TSFE']->tmpl->getFileName($instanceClass);
+				$instanceClass = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($instanceClass);
 			}
 			if (! file_exists($instanceClass)) {
 				GeneralUtility::devLog('Class \''.$instanceClass.'\' not found', 'imagecycle', 1);
@@ -131,12 +132,17 @@ class TtNewsUserFunctions {
 			/** @var tx_imagecycle_pi1 $obj */
 			$obj = GeneralUtility::makeInstance($instance);
 			$obj->setContentKey($obj->extKey . '_' . $this->cObj->data['uid']);
+			// @extensionScannerIgnoreLine
 			$obj->conf = $GLOBALS['TSFE']->tmpl->setup['plugin.'][$instance . '.'];
 			// overwrite the width and height of the config
+			// @extensionScannerIgnoreLine
 			$obj->conf['imagewidth'] = $GLOBALS['TSFE']->register['imagewidth'];
+			// @extensionScannerIgnoreLine
 			$obj->conf['imageheight'] = $GLOBALS['TSFE']->register['imageheight'];
 			if ($this->cObj->data['tx_imagecycle_duration'] > 0) {
+			    // @extensionScannerIgnoreLine
 				$obj->conf['displayDuration'] = $this->cObj->data['tx_imagecycle_duration'];
+				// @extensionScannerIgnoreLine
 				$obj->conf['nivoPauseTime'] = $this->cObj->data['tx_imagecycle_duration'];
 			}
 			$obj->cObj = $this->cObj;

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -3,20 +3,20 @@ defined('TYPO3_MODE') || die('Access denied.');
 
 $table = 'tt_content';
 
-$relativeExtensionPath = 'EXT:' . IMAGECYLCE_EXT . '/'; 
+$relativeExtensionPath = 'EXT:imagecycle/'; 
 
 // CONTENT
 $tempColumns = array(
     'tx_imagecycle_activate' => array(
         'exclude' => 1,
-        'label' => 'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.tx_imagecycle_activate',
+        'label' => 'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.tx_imagecycle_activate',
         'config' => array(
             'type' => 'check',
         )
     ),
     'tx_imagecycle_duration' => array(
         'exclude' => 1,
-        'label' => 'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.tx_imagecycle_duration',
+        'label' => 'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.tx_imagecycle_duration',
         'config' => array(
             'type' => 'input',
             'size' => '5',
@@ -31,24 +31,24 @@ $GLOBALS['TCA'][$table]['palettes']['tx_imagecycle'] = array(
     'showitem' => 'tx_imagecycle_activate,tx_imagecycle_duration',
     'canNotCollapse' => 1,
 );
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes($table, '--palette--;LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.tx_imagecycle_title;tx_imagecycle', 'textpic,image', 'before:imagecaption');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes($table, '--palette--;LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.tx_imagecycle_title;tx_imagecycle', 'textpic,image', 'before:imagecaption');
 
 $listType = 'imagecycle_pi1';
 
 // ICON pi1
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     array(
-        'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.list_type_pi1',
+        'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.list_type_pi1',
         $listType,
         $relativeExtensionPath . 'pi1/ce_icon.gif'
     ),
     'list_type',
-    IMAGECYLCE_EXT
+    'imagecycle'
 );
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $listType,
-    'FILE:EXT:' . IMAGECYLCE_EXT . '/pi1/flexform_ds.xml'
+    'FILE:EXT:imagecycle/pi1/flexform_ds.xml'
 );
 
 $listType = 'imagecycle_pi2';
@@ -56,16 +56,16 @@ $listType = 'imagecycle_pi2';
 // ICON pi2
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     array(
-        'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.list_type_pi2', 
+        'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.list_type_pi2',
         $listType,
         $relativeExtensionPath . 'pi2/ce_icon.gif'
     ),
     'list_type',
-    IMAGECYLCE_EXT
+    'imagecycle'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $listType,
-    'FILE:EXT:' . IMAGECYLCE_EXT . '/pi2/flexform_ds.xml'
+    'FILE:EXT:imagecycle/pi2/flexform_ds.xml'
 );
 
 $listType = 'imagecycle_pi3';
@@ -78,11 +78,11 @@ $listType = 'imagecycle_pi3';
         $relativeExtensionPath . 'pi3/ce_icon.gif'
     ),
     'list_type',
-    IMAGECYLCE_EXT
+    'imagecycle'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $listType, 
-    'FILE:EXT:' . IMAGECYLCE_EXT . '/pi3/flexform_ds.xml'
+    'FILE:EXT:imagecycle/pi3/flexform_ds.xml'
 );
 
 $listType = 'imagecycle_pi4';
@@ -90,16 +90,16 @@ $listType = 'imagecycle_pi4';
 // ICON pi4
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     array(
-        'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.list_type_pi4',
+        'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.list_type_pi4',
         $listType,
         $relativeExtensionPath . 'pi4/ce_icon.gif'
     ),
     'list_type',
-    IMAGECYLCE_EXT
+    'imagecycle'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $listType,
-    'FILE:EXT:' . IMAGECYLCE_EXT .'/pi4/flexform_ds.xml'
+    'FILE:EXT:imagecycle/pi4/flexform_ds.xml'
 );
 
 $listType = 'imagecycle_pi5';
@@ -107,16 +107,16 @@ $listType = 'imagecycle_pi5';
 // ICON pi5
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
     array(
-        'LLL:EXT:' . IMAGECYLCE_EXT . '/locallang_db.xml:' . $table . '.list_type_pi5',
+        'LLL:EXT:imagecycle/locallang_db.xml:' . $table . '.list_type_pi5',
         $listType,
         $relativeExtensionPath . 'pi5/ce_icon.gif'
     ),
     'list_type',
-    IMAGECYLCE_EXT
+    'imagecycle'
 );
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue(
     $listType,
-    'FILE:EXT:' . IMAGECYLCE_EXT . '/pi5/flexform_ds.xml'
+    'FILE:EXT:imagecycle/pi5/flexform_ds.xml'
 );
 
 $GLOBALS['TCA'][$table]['types']['list']['subtypes_excludelist']['imagecycle_pi1'] = 'layout,select_key,pages';

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,12 +1,12 @@
 <?php
 defined('TYPO3_MODE') || die('Access denied.');
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/', 'Image-Cycle');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/tt_content/', 'Image-Cycle for tt_content');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/', 'Image-Cycle');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/tt_content/', 'Image-Cycle for tt_content');
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/coinslider/', 'Coin-Slider');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/nivoslider/', 'Nivo-Slider');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/crossslide/', 'Cross-Slide');
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile(IMAGECYLCE_EXT, 'static/slicebox/',   'Slice-Box');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/coinslider/', 'Coin-Slider');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/nivoslider/', 'Nivo-Slider');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/crossslide/', 'Cross-Slide');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('imagecycle', 'static/slicebox/',   'Slice-Box');
 
 

--- a/pi1/class.tx_imagecycle_pi1.php
+++ b/pi1/class.tx_imagecycle_pi1.php
@@ -28,6 +28,10 @@ use TYPO3\CMS\Core\Resource\ResourceFactory;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Frontend\Plugin\AbstractPlugin;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
+use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3Extension\Imagecycle\Controller\PageRenderer;
 
 
 /**
@@ -74,7 +78,8 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 		$this->setContentKey('imagecycle');
 
 		// set the system language
-		$this->sys_language_uid = $GLOBALS['TSFE']->sys_language_content;
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $this->sysLanguageUid = $languageAspect->getId();
 
 		// set the uid of the tt_content
 		$this->uid = $this->cObj->data['_LOCALIZED_UID'] ? $this->cObj->data['_LOCALIZED_UID'] : $this->cObj->data['uid'];
@@ -246,8 +251,10 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 				}
 			}
 			if ($pageID) {
-				if ($this->sys_language_uid) {
-					$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sys_language_uid, '', '', 1);
+                if ($this->sysLanguageUid) {
+                    // @extensionScannerIgnoreLine
+                    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sysLanguageUid, '', '', 1);
+                    // @extensionScannerIgnoreLine
 					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
 					if (trim($used_page['tx_imagecycle_effect'])) {
 						$this->conf['type'] = $row['tx_imagecycle_effect'];
@@ -265,7 +272,7 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 						$this->hrefs    = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_hrefs']);
 						$this->captions = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_captions']);
 						// Language overlay
-						if ($this->sys_language_uid) {
+                        if ($this->sysLanguageUid) {
 							if (trim($row['tx_imagecycle_images']) != '') {
 								$this->images   = GeneralUtility::trimExplode(',',     $row['tx_imagecycle_images']);
 								$this->hrefs    = GeneralUtility::trimExplode(chr(10), $row['tx_imagecycle_hrefs']);
@@ -413,7 +420,8 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 	 */
 	public function parseTemplate($data=array(), $dir='', $onlyJS=false)
 	{
-		$this->pagerenderer = GeneralUtility::makeInstance(\TYPO3Extension\Imagecycle\Controller\PageRenderer::class);
+        $this->pagerenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class );
 		$this->pagerenderer->setConf($this->conf);
 
 		// define the directory of images
@@ -432,9 +440,12 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 		}
 
 		// The template for JS
-		if (! $this->templateFileJS = $this->cObj->fileResource($this->conf['templateFileJS'])) {
-			$this->templateFileJS = $this->cObj->fileResource('EXT:imagecycle/res/tx_imagecycle.js');
+        $template = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($this->conf['templateFileJS']);
+        if ($template !== null && file_exists($template)) {
+            $this->templateFileJS = file_get_contents($template);
 		}
+        else
+            $this->templateFileJS = file_get_contents('EXT:imagecycle/res/tx_imagecycle.js');
 
 		// set the key
 		$markerArray = array();
@@ -547,8 +558,10 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 		}
 		// 
 		if ($this->conf['showPager']) {
-			$templateActivatePagerCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_ACTIVATE_PAGER_JS###'));
-			$after .= $this->cObj->substituteMarkerArray($templateActivatePagerCode, $markerArray, '###|###', 0);
+            // @extensionScannerIgnoreLine
+            $templateActivatePagerCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_ACTIVATE_PAGER_JS###'));
+            // @extensionScannerIgnoreLine
+            $after .= $this->templateService->substituteMarkerArray($templateActivatePagerCode, $markerArray, '###|###', 0);
 		}
 		if ($before) {
 			$options['before'] = 'before: function(a,n,o,f) {' . $before .' }';
@@ -573,67 +586,89 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 		$this->pagerenderer->addCssFile($this->conf['cssFile']);
 
 		// get the Template of the Javascript
-		if (! $templateCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_JS###'))) {
+        // @extensionScannerIgnoreLine
+        if (! $templateCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_JS###'))) {
 			$templateCode = 'alert(\'Template TEMPLATE_JS is missing\')';
 		}
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		// Show the caption when sync is turned off
 		if ($this->conf['showcaption'] && ! $this->conf['captionSync']) {
-			$templateShowCaption = trim($this->cObj->getSubpart($templateCode, '###SHOW_CAPTION_AT_START###'));
+            // @extensionScannerIgnoreLine
+            $templateShowCaption = trim($this->templateService->getSubpart($templateCode, '###SHOW_CAPTION_AT_START###'));
 		} else {
 			$templateShowCaption = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###SHOW_CAPTION_AT_START###', $templateShowCaption, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###SHOW_CAPTION_AT_START###', $templateShowCaption, 0);
 
 		// define the control
 		if ($this->conf['showControl']) {
-			$templateControl = trim($this->cObj->getSubpart($templateCode, '###CONTROL###'));
-			$templateControlAfter = trim($this->cObj->getSubpart($templateCode, '###CONTROL_AFTER###'));
-			$options[] = trim($this->cObj->getSubpart($templateCode, '###CONTROL_OPTIONS###'));
+            // @extensionScannerIgnoreLine
+            $templateControl = trim($this->templateService->getSubpart($templateCode, '###CONTROL###'));
+            // @extensionScannerIgnoreLine
+            $templateControlAfter = trim($this->templateService->getSubpart($templateCode, '###CONTROL_AFTER###'));
+            // @extensionScannerIgnoreLine
+            $options[] = trim($this->templateService->getSubpart($templateCode, '###CONTROL_OPTIONS###'));
 		} else {
 			$templateControl = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###CONTROL###', $templateControl, 0);
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###CONTROL_AFTER###', $templateControlAfter, 0);
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###CONTROL_OPTIONS###', '', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###CONTROL###', $templateControl, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###CONTROL_AFTER###', $templateControlAfter, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###CONTROL_OPTIONS###', '', 0);
 
 		// define the play class
 		if ($this->conf['pausedBegin']) {
-			$templatePaused = $this->cObj->getSubpart($templateCode, '###PAUSED###');
-			$templatePausedBegin = $this->cObj->getSubpart($templateCode, '###PAUSED_BEGIN###');
+            // @extensionScannerIgnoreLine
+            $templatePaused = $this->templateService->getSubpart($templateCode, '###PAUSED###');
+            // @extensionScannerIgnoreLine
+            $templatePausedBegin = $this->templateService->getSubpart($templateCode, '###PAUSED_BEGIN###');
 		} else {
 			$templatePaused = null;
 			$templatePausedBegin = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###PAUSED###', $templatePaused, 0);
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###PAUSED_BEGIN###', $templatePausedBegin, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###PAUSED###', $templatePaused, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###PAUSED_BEGIN###', $templatePausedBegin, 0);
 
 		// define the pager
 		if ($this->conf['showPager']) {
-			$templatePager = $this->cObj->getSubpart($templateCode, '###PAGER###');
+            // @extensionScannerIgnoreLine
+            $templatePager = $this->templateService->getSubpart($templateCode, '###PAGER###');
 		} else {
 			$templatePager = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###PAGER###', $templatePager, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###PAGER###', $templatePager, 0);
 
 		// Slow connection will have a load to start
 		if ($this->conf['fixSlowConnection']) {
-			$templateSlowBefore = $this->cObj->getSubpart($templateCode, '###SLOW_CONNECTION_BEFORE###');
-			$templateSlowAfter  = $this->cObj->getSubpart($templateCode, '###SLOW_CONNECTION_AFTER###');
+            // @extensionScannerIgnoreLine
+            $templateSlowBefore = $this->templateService->getSubpart($templateCode, '###SLOW_CONNECTION_BEFORE###');
+            // @extensionScannerIgnoreLine
+            $templateSlowAfter  = $this->templateService->getSubpart($templateCode, '###SLOW_CONNECTION_AFTER###');
 		} else {
 			$templateSlowBefore = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###SLOW_CONNECTION_BEFORE###', $templateSlowBefore, 0);
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###SLOW_CONNECTION_AFTER###',  $templateSlowAfter, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###SLOW_CONNECTION_BEFORE###', $templateSlowBefore, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###SLOW_CONNECTION_AFTER###',  $templateSlowAfter, 0);
 
 		// If only one image is displayed, the caption will be show
 		if (is_array($data) && count($data) == 1) {
-			$templateOnlyOneImage = $this->cObj->getSubpart($templateCode, '###ONLY_ONE_IMAGE###');
+            // @extensionScannerIgnoreLine
+            $templateOnlyOneImage = $this->templateService->getSubpart($templateCode, '###ONLY_ONE_IMAGE###');
 		} else {
 			$templateOnlyOneImage = null;
 		}
-		$templateCode = $this->cObj->substituteSubpart($templateCode, '###ONLY_ONE_IMAGE###', $templateOnlyOneImage, 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteSubpart($templateCode, '###ONLY_ONE_IMAGE###', $templateOnlyOneImage, 0);
 
 		// define the markers
 		$markerArray = array();
@@ -641,7 +676,8 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 		$markerArray['CAPTION_TAG'] = $captionTag;
 
 		// set the markers
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		$this->pagerenderer->addJS($jQueryNoConflict . $templateCode);
 
@@ -709,7 +745,8 @@ class tx_imagecycle_pi1 extends AbstractPlugin
 			$markerArray['PAGER'] = $this->cObj->stdWrap($pager, $this->conf['cycle.'][$this->type.'.']['pagerWrap.']);
 			// the stdWrap
 			$images = $this->cObj->stdWrap($images, $this->conf['cycle.'][$this->type.'.']['stdWrap.']);
-			$return_string = $this->cObj->substituteMarkerArray($images, $markerArray, '###|###', 0);
+            // @extensionScannerIgnoreLine
+            $return_string = $this->templateService->substituteMarkerArray($images, $markerArray, '###|###', 0);
 			// add the noscript
 			$return_string .= $no_script;
 		}

--- a/pi1/flexform_ds.xml
+++ b/pi1/flexform_ds.xml
@@ -176,7 +176,7 @@
 							<label></label>
 							<config>
 								<type>user</type>
-                                <userFunc>\TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
+                                <userFunc>TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
 							</config>
 						</TCEforms>
 					</hideRTE>

--- a/pi2/class.tx_imagecycle_pi2.php
+++ b/pi2/class.tx_imagecycle_pi2.php
@@ -24,6 +24,8 @@
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
+use TYPO3Extension\Imagecycle\Controller\PageRenderer;
 
 /**
  * [CLASS/FUNCTION INDEX of SCRIPT]
@@ -77,7 +79,8 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 		$this->setContentKey('imagecycle-coin');
 
 		// set the system language
-		$this->sys_language_uid = $GLOBALS['TSFE']->sys_language_content;
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $this->sysLanguageUid = $languageAspect->getId();
 
 		// set the uid of the tt_content
 		$this->uid = $this->cObj->data['_LOCALIZED_UID'] ? $this->cObj->data['_LOCALIZED_UID'] : $this->cObj->data['uid'];
@@ -214,8 +217,10 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 				}
 			}
 			if ($pageID) {
-				if ($this->sys_language_uid) {
-					$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sys_language_uid, '', '', 1);
+                if ($this->sysLanguageUid) {
+                    // @extensionScannerIgnoreLine
+                    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sysLanguageUid, '', '', 1);
+                    // @extensionScannerIgnoreLine
 					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
 					if (trim($used_page['tx_imagecycle_effect'])) {
 						$this->conf['type'] = $row['tx_imagecycle_effect'];
@@ -233,7 +238,7 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 						$this->hrefs    = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_hrefs']);
 						$this->captions = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_captions']);
 						// Language overlay
-						if ($this->sys_language_uid) {
+                        if ($this->sysLanguageUid) {
 							if (trim($row['tx_imagecycle_images']) != '') {
 								$this->images   = GeneralUtility::trimExplode(',',     $row['tx_imagecycle_images']);
 								$this->hrefs    = GeneralUtility::trimExplode(chr(10), $row['tx_imagecycle_hrefs']);
@@ -282,7 +287,8 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 	 */
 	public function parseTemplate($data=array(), $dir='', $onlyJS=false)
 	{
-		$this->pagerenderer = GeneralUtility::makeInstance(\TYPO3Extension\Imagecycle\Controller\PageRenderer);
+        $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
+        $this->pagerenderer = GeneralUtility::makeInstance(PageRenderer::class);
 		$this->pagerenderer->setConf($this->conf);
 
 		// define the directory of images
@@ -383,9 +389,12 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 		}
 
 		// The template for JS
-		if (! $this->templateFileJS = $this->cObj->fileResource($this->conf['templateFileJS'])) {
-			$this->templateFileJS = $this->cObj->fileResource('EXT:imagecycle/res/tx_imagecycle.js');
+        $template = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($this->conf['templateFileJS']);
+        if ($template !== null && file_exists($template)) {
+            $this->templateFileJS = file_get_contents($template);
 		}
+        else
+            $this->templateFileJS = file_get_contents('EXT:imagecycle/res/tx_imagecycle.js');
 
 		// define the jQuery mode and function
 		if ($this->conf['jQueryNoConflict']) {
@@ -401,7 +410,7 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 		$options['height'] = 'height: \'' . $maxHeight . '\'';
 
 		$this->pagerenderer->addCSS('
-#c{$this->cObj->data['uid']} {
+        #c{$this->cObj->data[\'uid\']} {
 	width: ' . $maxWidth . 'px;
 }');
 
@@ -449,7 +458,8 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 		$this->pagerenderer->addJsFile($this->conf['jQueryCoin']);
 
 		// get the Template of the Javascript
-		if (! $templateCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_COINSLIDER_JS###'))) {
+        // @extensionScannerIgnoreLine
+        if (! $templateCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_COINSLIDER_JS###'))) {
 			$templateCode = 'alert(\'Template TEMPLATE_COINSLIDER_JS is missing\')';
 		}
 
@@ -459,7 +469,8 @@ class tx_imagecycle_pi2 extends tx_imagecycle_pi1
 		$markerArray['OPTIONS'] = implode(',' . PHP_EOL . '		', $options);
 
 		// set the markers
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		$this->pagerenderer->addJS($jQueryNoConflict . $templateCode);
 

--- a/pi2/flexform_ds.xml
+++ b/pi2/flexform_ds.xml
@@ -176,7 +176,7 @@
 							<label></label>
 							<config>
 								<type>user</type>
-                                <userFunc>\TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
+                                <userFunc>TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
 							</config>
 						</TCEforms>
 					</hideRTE>

--- a/pi3/class.tx_imagecycle_pi3.php
+++ b/pi3/class.tx_imagecycle_pi3.php
@@ -24,6 +24,10 @@
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
+use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3Extension\Imagecycle\Controller\PageRenderer;
 
 /**
  * [CLASS/FUNCTION INDEX of SCRIPT]
@@ -77,7 +81,8 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 		$this->setContentKey('imagecycle-nivo');
 
 		// set the system language
-		$this->sys_language_uid = $GLOBALS['TSFE']->sys_language_content;
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $this->sysLanguageUid = $languageAspect->getId();
 
 		// set the uid of the tt_content
 		$this->uid = $this->cObj->data['_LOCALIZED_UID'] ? $this->cObj->data['_LOCALIZED_UID'] : $this->cObj->data['uid'];
@@ -259,8 +264,10 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 				}
 			}
 			if ($pageID) {
-				if ($this->sys_language_uid) {
-					$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sys_language_uid, '', '', 1);
+                if ($this->sysLanguageUid) {
+                    // @extensionScannerIgnoreLine
+                    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sysLanguageUid, '', '', 1);
+                    // @extensionScannerIgnoreLine
 					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
 					if (trim($used_page['tx_imagecycle_effect'])) {
 						$this->conf['type'] = $row['tx_imagecycle_effect'];
@@ -278,7 +285,7 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 						$this->hrefs    = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_hrefs']);
 						$this->captions = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_captions']);
 						// Language overlay
-						if ($this->sys_language_uid) {
+                        if ($this->sysLanguageUid) {
 							if (trim($row['tx_imagecycle_images']) != '') {
 								$this->images   = GeneralUtility::trimExplode(',',     $row['tx_imagecycle_images']);
 								$this->hrefs    = GeneralUtility::trimExplode(chr(10), $row['tx_imagecycle_hrefs']);
@@ -327,7 +334,8 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 	 */
 	public function parseTemplate($data=array(), $dir='', $onlyJS=false)
 	{
-		$this->pagerenderer = GeneralUtility::makeInstance(\TYPO3Extension\Imagecycle\Controller\PageRenderer);
+        $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
+        $this->pagerenderer = GeneralUtility::makeInstance(PageRenderer::class);
 		$this->pagerenderer->setConf($this->conf);
 
 		// define the directory of images
@@ -472,9 +480,12 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 		}
 
 		// The template for JS
-		if (! $this->templateFileJS = $this->cObj->fileResource($this->conf['templateFileJS'])) {
-			$this->templateFileJS = $this->cObj->fileResource('EXT:imagecycle/res/tx_imagecycle.js');
+        $template = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($this->conf['templateFileJS']);
+        if ($template !== null && file_exists($template)) {
+            $this->templateFileJS = file_get_contents($template);
 		}
+        else
+            $this->templateFileJS = file_get_contents('EXT:imagecycle/res/tx_imagecycle.js');
 
 		// define the jQuery mode and function
 		if ($this->conf['jQueryNoConflict']) {
@@ -505,11 +516,11 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 		$options['effect'] = 'effect: \'' . $this->conf['nivoEffect'] . '\'';
 
 		// Set the language for prev and next
-		$options['prev'] = 'prevText: \'' . GeneralUtility::slashJS($this->pi_getLL('prev')) . '\'';
-		$options['next'] = 'nextText: \'' . GeneralUtility::slashJS($this->pi_getLL('next')) . '\'';
+        $options['prev'] = "prevText: '".$this->pi_getLL('prev')."'";
+        $options['next'] = "nextText: '".$this->pi_getLL('next')."'";
 
 		if ($this->conf['nivoSlices'] > 0) {
-			$options['slices'] = 'slices: ' . $this->conf['nivoSlices'] . '\'';
+            $options['slices'] = 'slices: ' . $this->conf['nivoSlices'];
 		}
 		if ($this->conf['nivoBoxCols'] > 0) {
 			$options['boxCols'] = 'boxCols: ' . $this->conf['nivoBoxCols'];
@@ -563,7 +574,8 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 		$this->pagerenderer->addJsFile($this->conf['jQueryNivo']);
 
 		// get the Template of the Javascript
-		if (! $templateCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_NIVOSLIDER_JS###'))) {
+        // @extensionScannerIgnoreLine
+        if (! $templateCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_NIVOSLIDER_JS###'))) {
 			$templateCode = 'alert(\'Template TEMPLATE_NIVOSLIDER_JS is missing\')';
 		}
 
@@ -573,7 +585,8 @@ class tx_imagecycle_pi3 extends tx_imagecycle_pi1
 		$markerArray['OPTIONS'] = implode(',' . PHP_EOL . '		', $options);
 
 		// set the markers
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		$this->pagerenderer->addJS($jQueryNoConflict . $templateCode);
 

--- a/pi3/flexform_ds.xml
+++ b/pi3/flexform_ds.xml
@@ -176,7 +176,7 @@
 							<label></label>
 							<config>
 								<type>user</type>
-                                <userFunc>\TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
+                                <userFunc>TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
 							</config>
 						</TCEforms>
 					</hideRTE>

--- a/pi4/class.tx_imagecycle_pi4.php
+++ b/pi4/class.tx_imagecycle_pi4.php
@@ -24,6 +24,10 @@
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
+use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
+use TYPO3\CMS\Core\Context\Context;
+use TYPO3Extension\Imagecycle\Controller\PageRenderer;
 
 /**
  * [CLASS/FUNCTION INDEX of SCRIPT]
@@ -77,7 +81,8 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 		$this->setContentKey('imagecycle-cross');
 
 		// set the system language
-		$this->sys_language_uid = $GLOBALS['TSFE']->sys_language_content;
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $this->sysLanguageUid = $languageAspect->getId();
 
 		// set the uid of the tt_content
 		$this->uid = $this->cObj->data['_LOCALIZED_UID'] ? $this->cObj->data['_LOCALIZED_UID'] : $this->cObj->data['uid'];
@@ -204,8 +209,10 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 				}
 			}
 			if ($pageID) {
-				if ($this->sys_language_uid) {
-					$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sys_language_uid, '', '', 1);
+                if ($this->sysLanguageUid) {
+                    // @extensionScannerIgnoreLine
+                    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sysLanguageUid, '', '', 1);
+                    // @extensionScannerIgnoreLine
 					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
 					if (trim($used_page['tx_imagecycle_effect'])) {
 						$this->conf['type'] = $row['tx_imagecycle_effect'];
@@ -223,7 +230,7 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 						$this->hrefs    = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_hrefs']);
 						$this->captions = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_captions']);
 						// Language overlay
-						if ($this->sys_language_uid) {
+                        if ($this->sysLanguageUid) {
 							if (trim($row['tx_imagecycle_images']) != '') {
 								$this->images   = GeneralUtility::trimExplode(',',     $row['tx_imagecycle_images']);
 								$this->hrefs    = GeneralUtility::trimExplode(chr(10), $row['tx_imagecycle_hrefs']);
@@ -277,7 +284,8 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 	 */
 	public function parseTemplate($data=array(), $dir='', $onlyJS=false)
 	{
-		$this->pagerenderer = GeneralUtility::makeInstance(\TYPO3Extension\Imagecycle\Controller\PageRenderer);
+        $this->pagerenderer = GeneralUtility::makeInstance(PageRenderer::class);
+        $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class );
 		$this->pagerenderer->setConf($this->conf);
 
 		// define the directory of images
@@ -368,9 +376,12 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 		}
 
 		// The template for JS
-		if (! $this->templateFileJS = $this->cObj->fileResource($this->conf['templateFileJS'])) {
-			$this->templateFileJS = $this->cObj->fileResource('EXT:imagecycle/res/tx_imagecycle.js');
+        $template = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($this->conf['templateFileJS']);
+        if ($template !== null && file_exists($template)) {
+            $this->templateFileJS = file_get_contents($template);
 		}
+        else
+            $this->templateFileJS = file_get_contents('EXT:imagecycle/res/tx_imagecycle.js');
 
 		// define the jQuery mode and function
 		if ($this->conf['jQueryNoConflict']) {
@@ -419,7 +430,8 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 		$this->pagerenderer->addCssFile($this->conf['cssFileCross']);
 
 		// get the Template of the Javascript
-		if (! $templateCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_CROSSSLIDER_JS###'))) {
+        // @extensionScannerIgnoreLine
+        if (! $templateCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_CROSSSLIDER_JS###'))) {
 			$templateCode = 'alert(\'Template TEMPLATE_CROSSSLIDER_JS is missing\')';
 		}
 
@@ -430,7 +442,8 @@ class tx_imagecycle_pi4 extends tx_imagecycle_pi1
 		$markerArray['IMAGES'] = $imagesString;
 
 		// set the markers
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		$this->pagerenderer->addJS($jQueryNoConflict . $templateCode);
 

--- a/pi4/flexform_ds.xml
+++ b/pi4/flexform_ds.xml
@@ -176,7 +176,7 @@
 							<label></label>
 							<config>
 								<type>user</type>
-                                <userFunc>\TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
+                                <userFunc>TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
 							</config>
 						</TCEforms>
 					</hideRTE>

--- a/pi5/class.tx_imagecycle_pi5.php
+++ b/pi5/class.tx_imagecycle_pi5.php
@@ -24,6 +24,9 @@
 
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Frontend\Resource\FilePathSanitizer;
+use TYPO3\CMS\Core\Service\MarkerBasedTemplateService;
+use TYPO3Extension\Imagecycle\Controller\PageRenderer;
 
 /**
  * [CLASS/FUNCTION INDEX of SCRIPT]
@@ -77,7 +80,8 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 		$this->setContentKey('imagecycle-slice');
 
 		// set the system language
-		$this->sys_language_uid = $GLOBALS['TSFE']->sys_language_content;
+        $languageAspect = GeneralUtility::makeInstance(Context::class)->getAspect('language');
+        $this->sysLanguageUid = $languageAspect->getId();
 
 		// set the uid of the tt_content
 		$this->uid = $this->cObj->data['_LOCALIZED_UID'] ? $this->cObj->data['_LOCALIZED_UID'] : $this->cObj->data['uid'];
@@ -230,8 +234,10 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 				}
 			}
 			if ($pageID) {
-				if ($this->sys_language_uid) {
-				$res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sys_language_uid, '', '', 1);
+                if ($this->sysLanguageUid) {
+                    // @extensionScannerIgnoreLine
+                    $res = $GLOBALS['TYPO3_DB']->exec_SELECTquery('tx_imagecycle_images, tx_imagecycle_hrefs, tx_imagecycle_captions, tx_imagecycle_effect, tx_imagecycle_mode', 'pages_language_overlay', 'pid='.intval($pageID).' AND sys_language_uid='.$this->sysLanguageUid, '', '', 1);
+                    // @extensionScannerIgnoreLine
 					$row = $GLOBALS['TYPO3_DB']->sql_fetch_assoc($res);
 					if (trim($used_page['tx_imagecycle_effect'])) {
 						$this->conf['type'] = $row['tx_imagecycle_effect'];
@@ -249,7 +255,7 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 						$this->hrefs    = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_hrefs']);
 						$this->captions = GeneralUtility::trimExplode(chr(10), $used_page['tx_imagecycle_captions']);
 						// Language overlay
-						if ($this->sys_language_uid) {
+                        if ($this->sysLanguageUid) {
 							if (trim($row['tx_imagecycle_images']) != '') {
 								$this->images   = GeneralUtility::trimExplode(',',     $row['tx_imagecycle_images']);
 								$this->hrefs    = GeneralUtility::trimExplode(chr(10), $row['tx_imagecycle_hrefs']);
@@ -298,7 +304,8 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 	 */
 	public function parseTemplate($data=array(), $dir='', $onlyJS=false)
 	{
-		$this->pagerenderer = GeneralUtility::makeInstance(\TYPO3Extension\Imagecycle\Controller\PageRenderer);
+        $this->templateService = GeneralUtility::makeInstance(MarkerBasedTemplateService::class);
+        $this->pagerenderer = GeneralUtility::makeInstance(PageRenderer::class);
 		$this->pagerenderer->setConf($this->conf);
 
 		// define the directory of images
@@ -395,7 +402,7 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 			$options['orientation'] = 'orientation: \'' . $this->conf['sliceOrientation'] . '\'';
 		}
 		if ($this->conf['slicePerspective'] > 0) {
-			$options['perspective'] = 'perspective: ' . $this->conf['slicePerspective']' . '\'';
+            $options['perspective'] = 'perspective: ' . $this->conf['slicePerspective'];
 		}
 		if ($this->conf['sliceSlicesCount'] > 0) {
 			$options['cuboidsCount'] = 'cuboidsCount: ' . $this->conf['sliceSlicesCount'];
@@ -444,12 +451,16 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 		$this->pagerenderer->addJsFile($this->conf['jQuerySlice']);
 
 		// The template for JS
-		if (! $this->templateFileJS = $this->cObj->fileResource($this->conf['templateFileJS'])) {
-			$this->templateFileJS = $this->cObj->fileResource('EXT:imagecycle/res/tx_imagecycle.js');
+        $template = GeneralUtility::makeInstance(FilePathSanitizer::class)->sanitize($this->conf['templateFileJS']);
+        if ($template !== null && file_exists($template)) {
+            $this->templateFileJS = file_get_contents($template);
 		}
+        else
+            $this->templateFileJS = file_get_contents('EXT:imagecycle/res/tx_imagecycle.js');
 
 		// get the Template of the Javascript
-		if (! $templateCode = trim($this->cObj->getSubpart($this->templateFileJS, '###TEMPLATE_SLICEBOX_JS###'))) {
+        // @extensionScannerIgnoreLine
+        if (! $templateCode = trim($this->templateService->getSubpart($this->templateFileJS, '###TEMPLATE_SLICEBOX_JS###'))) {
 			$templateCode = 'alert(\'Template TEMPLATE_SLICEBOX_JS is missing\')';
 		}
 
@@ -459,7 +470,8 @@ class tx_imagecycle_pi5 extends tx_imagecycle_pi1
 		$markerArray['OPTIONS'] = implode(',' . PHP_EOL . '				', $options);
 
 		// set the markers
-		$templateCode = $this->cObj->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
+        // @extensionScannerIgnoreLine
+        $templateCode = $this->templateService->substituteMarkerArray($templateCode, $markerArray, '###|###', 0);
 
 		$this->pagerenderer->addJS($jQueryNoConflict . $templateCode);
 

--- a/pi5/flexform_ds.xml
+++ b/pi5/flexform_ds.xml
@@ -176,7 +176,7 @@
 							<label></label>
 							<config>
 								<type>user</type>
-                                <userFunc>\TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
+                                <userFunc>TYPO3Extension\Imagecycle\Backend\TcaForm->hideRTE</userFunc>
 							</config>
 						</TCEforms>
 					</hideRTE>


### PR DESCRIPTION
Implemented changes for ImageCycle to support Typo3 9.5. In my Typo3 9.5 installation with these changes ImageCycle works like in Typo3 7 or 8. However, as I'm not a Typo3 expert, it would be great if someone could review the changes carefully before incorporating them into the main trunk.
Also my changes assume that the extension "typo3db_legacy" is installed. Otherwise ImageCycle still does not work.